### PR TITLE
Improved Idle between attacks and changed how attack range works

### DIFF
--- a/ProjectKaeru/Assets/Animation/Skeleton/Idle_0.controller
+++ b/ProjectKaeru/Assets/Animation/Skeleton/Idle_0.controller
@@ -17,11 +17,11 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.63414633
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
+  m_ExitTime: 0.00000002348803
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
@@ -36,7 +36,7 @@ AnimatorState:
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: 4192212137035939924}
+  - {fileID: 4757591343966878369}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -125,9 +125,9 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.5
+  m_ExitTime: 1
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
@@ -147,25 +147,25 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsDead
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Attack
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Idle
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -212,7 +212,7 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: -4481900184117041629}
-    m_Position: {x: -100, y: 60, z: 0}
+    m_Position: {x: 380, y: 60, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -7209153863226685475}
     m_Position: {x: 280, y: -70, z: 0}
@@ -286,7 +286,7 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1101 &4192212137035939924
+--- !u!1101 &4757591343966878369
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -295,13 +295,13 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions: []
   m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -5740368184177014606}
+  m_DstState: {fileID: -4481900184117041629}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
   m_TransitionDuration: 0
-  m_TransitionOffset: 0.0036240802
+  m_TransitionOffset: 0.0014725936
   m_ExitTime: 0.9999998
   m_HasExitTime: 1
   m_HasFixedDuration: 1

--- a/ProjectKaeru/Assets/Scenes/BrennanScene.unity
+++ b/ProjectKaeru/Assets/Scenes/BrennanScene.unity
@@ -22493,6 +22493,18 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3392338203020194560, guid: c76c9c66293109e449055c31908fa064, type: 3}
+      propertyPath: hitboxRadius
+      value: 0.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3392338203020194560, guid: c76c9c66293109e449055c31908fa064, type: 3}
+      propertyPath: attackCooldown
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3392338203020194560, guid: c76c9c66293109e449055c31908fa064, type: 3}
+      propertyPath: enemyAttackRange
+      value: 1.65
+      objectReference: {fileID: 0}
     - target: {fileID: 3392338203020194563, guid: c76c9c66293109e449055c31908fa064, type: 3}
       propertyPath: m_Name
       value: Skeleton (1)
@@ -22539,6 +22551,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3392338203020194571, guid: c76c9c66293109e449055c31908fa064, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3392338203020194572, guid: c76c9c66293109e449055c31908fa064, type: 3}
+      propertyPath: m_Constraints
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 3392338203020194575, guid: c76c9c66293109e449055c31908fa064, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3392338203020194575, guid: c76c9c66293109e449055c31908fa064, type: 3}
+      propertyPath: m_IsTrigger
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/ProjectKaeru/Assets/Scripts/EnemyAI.cs
+++ b/ProjectKaeru/Assets/Scripts/EnemyAI.cs
@@ -80,26 +80,27 @@ public class EnemyAI : MonoBehaviour
     void FixedUpdate()
     //Current Problems:
     //We constantly pathfind, but it should be possible to limit it to only pathfind when the player is in range
-    //Create a wall detection gameobject so we can turn around when we bump into a wall
     //Work on animation transitions
     //Combine this script with the basic enemy script
     //Figure out how Mac's attack script works. His hitboxes might actually last for more than a frame.
-    //Add the wall detection gameobject child
 
     {
-        if (Math.Abs(Vector3.Distance(target.transform.position, transform.position)) < enemyAttackRange) //If in attack range, try to attack the player
+        //Debug.Log(Math.Abs(Vector3.Distance(target.transform.position, transform.position)));
+        Collider2D rangeHitbox = Physics2D.OverlapCircle(transform.position, enemyAttackRange, LayerMask.GetMask("Player"));
+        if (rangeHitbox != null) //If in attack range, try to attack the player
         {
             //Maybe set canIMove to false during this time
+            animator.SetBool("Idle", true);
             if (attackCooldownTracker <= 0)
             {
                 //we can attack
 
                 //throw up a collider to try to attack the player
                 animator.SetTrigger("Attack");
-                Collider2D player = Physics2D.OverlapCircle(attackPos.position, hitboxRadius, LayerMask.GetMask("Player"));
+                Collider2D attackHitbox = Physics2D.OverlapCircle(attackPos.position, hitboxRadius, LayerMask.GetMask("Player"));
                 //Tells the player they've been hit
                 //Only works if the player is actually hit by the attack
-                if (player != null)
+                if (attackHitbox != null)
                 {
                     //player.GetComponent<PlayerCombat>().hitByEnemy(damage);
                 }
@@ -114,6 +115,7 @@ public class EnemyAI : MonoBehaviour
             {
                 attackCooldownTracker -= Time.fixedDeltaTime;
             }
+            animator.SetBool("Idle", false);
 
         }
         else if (Math.Abs(Vector3.Distance(target.transform.position, transform.position)) < enemyDetectionRange) //If in detect range, move towards the player
@@ -234,6 +236,9 @@ public class EnemyAI : MonoBehaviour
     private void OnDrawGizmosSelected() //draws the hitbox for our attack
     {
         Gizmos.color = Color.red;
-        Gizmos.DrawWireSphere(attackPos.position, hitboxRadius);
+        Gizmos.DrawWireSphere(attackPos.position, hitboxRadius); //weapon attack hitbox
+
+        Gizmos.color = Color.black;
+        Gizmos.DrawWireSphere(attackPos.position, enemyAttackRange); //attack range hitbox
     }
 }


### PR DESCRIPTION
Idle - The skeleton will now use the idle animation between attacks instead of walking between attacks. Looks better if he's stationary.

The enemy's attack range used to be determined by a distance calcualtion. It is now determined by creating a circle collider around the enemy. This gives a much more accurate radius/range for when we can attack.

Could still probably be improved to something like a box collider around the attack pos gamechild.